### PR TITLE
Use kwargs in test_subscriber_client

### DIFF
--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -73,7 +73,9 @@ def test_subscribe(manager_open):
 
     assert future._manager._subscription == "sub_name_a"
     manager_open.assert_called_once_with(
-        mock.ANY, mock.sentinel.callback, future.set_exception
+        mock.ANY,
+        callback=mock.sentinel.callback,
+        on_callback_error=future.set_exception,
     )
 
 
@@ -100,5 +102,7 @@ def test_subscribe_options(manager_open):
     assert future._manager.flow_control == flow_control
     assert future._manager._scheduler == scheduler
     manager_open.assert_called_once_with(
-        mock.ANY, mock.sentinel.callback, future.set_exception
+        mock.ANY,
+        callback=mock.sentinel.callback,
+        on_callback_error=future.set_exception,
     )


### PR DESCRIPTION
This prevents test failures in case the ordering of the keyword arguments to the `StreamingPullManager.open` is switched